### PR TITLE
Make "bundle install" for macOS Mojave

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'grape-entity',                     '~> 0.7.1'
 gem 'grape_logging',                    '~> 1.8'
 gem 'jwt-multisig',                     '~> 1.0'
 gem 'memoist',                          '~> 0.16'
-gem 'mini_racer',                       '~> 0.1', require: false
+gem 'mini_racer',                       '~> 0.2', require: false
 gem 'mysql2',                           '>= 0.3.18', '< 0.5'
 gem 'puma',                             '~> 3.7'
 gem 'rails',                            '~> 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     jwt-multisig (1.0.0)
       activesupport (>= 4.0, < 6.0)
       jwt (~> 2.1)
-    libv8 (6.3.292.48.1)
+    libv8 (6.7.288.46.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -134,8 +134,8 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    mini_racer (0.1.15)
-      libv8 (~> 6.3)
+    mini_racer (0.2.4)
+      libv8 (>= 6.3)
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -288,7 +288,7 @@ DEPENDENCIES
   jwt-multisig (~> 1.0)
   listen (>= 3.0.5, < 3.2)
   memoist (~> 0.16)
-  mini_racer (~> 0.1)
+  mini_racer (~> 0.2)
   mysql2 (>= 0.3.18, < 0.5)
   pry-byebug (~> 3.5)
   puma (~> 3.7)
@@ -303,4 +303,4 @@ DEPENDENCIES
   webmock (~> 3.3)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
Fetching mini_racer 0.1.15
Installing mini_racer 0.1.15 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/sikamedia/.rvm/gems/ruby-2.5.0@applogic/gems/mini_racer-0.1.15/ext/mini_racer_extension
/Users/sikamedia/.rvm/rubies/ruby-2.5.0/bin/ruby -r ./siteconf20190309-41267-cfon6g.rb extconf.rb
checking for -lpthread... yes
checking for -lobjc... yes
creating Makefile

current directory: /Users/sikamedia/.rvm/gems/ruby-2.5.0@applogic/gems/mini_racer-0.1.15/ext/mini_racer_extension
make "DESTDIR=" clean

current directory: /Users/sikamedia/.rvm/gems/ruby-2.5.0@applogic/gems/mini_racer-0.1.15/ext/mini_racer_extension
make "DESTDIR="
compiling mini_racer_extension.cc
clang: warning: argument unused during compilation: '-rdynamic' [-Wunused-command-line-argument]
In file included from mini_racer_extension.cc:2:
In file included from /Users/sikamedia/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby.h:33:
In file included from /Users/sikamedia/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/ruby.h:2036:
/Users/sikamedia/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/intern.h:47:19: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
void rb_mem_clear(register VALUE*, register long);
                  ^~~~~~~~~
/Users/sikamedia/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/intern.h:47:36: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
void rb_mem_clear(register VALUE*, register long);
                                   ^~~~~~~~~
2 warnings generated.
linking shared-object mini_racer_extension.bundle
clang: warning: libstdc++ is deprecated; move to libc++ [-Wdeprecated]
ld: library not found for -lstdc++
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [mini_racer_extension.bundle] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/sikamedia/.rvm/gems/ruby-2.5.0@applogic/gems/mini_racer-0.1.15 for inspection.
Results logged to /Users/sikamedia/.rvm/gems/ruby-2.5.0@applogic/extensions/x86_64-darwin-18/2.5.0/mini_racer-0.1.15/gem_make.out

An error occurred while installing mini_racer (0.1.15), and Bundler cannot continue.
Make sure that `gem install mini_racer -v '0.1.15' --source 'https://rubygems.org/'` succeeds before bundling.
